### PR TITLE
TestOutputHelperExtensions.BuildLoggerFor return type

### DIFF
--- a/Neovolve.UnitTest.UnitTests/Logging/CacheLoggerProviderTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/CacheLoggerProviderTests.cs
@@ -1,0 +1,65 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using ModelBuilder;
+using Neovolve.UnitTest.Logging;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Neovolve.UnitTest.UnitTests.Logging
+{
+    public class CacheLoggerProviderTests
+    {
+        [Fact]
+        public void CanDisposeMultipleTimesTest()
+        {
+            var logs = new List<LogEntry>();
+
+            using (var sut = new CacheLoggerProvider(logs))
+            {
+                Action action = () => sut.Dispose();
+
+                action.Should().NotThrow();
+            }
+        }
+
+        [Fact]
+        public void CreateLoggerReturnsCacheLoggerWithProvidedLogsStorageTest()
+        {
+            var eventId = Model.Create<EventId>();
+            var state = Guid.NewGuid().ToString();
+            var data = Guid.NewGuid().ToString();
+            var exception = new ArgumentNullException(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            Func<string, Exception, string> formatter = (string message, Exception error) =>
+            {
+                return data;
+            };
+            var name = Guid.NewGuid().ToString();
+            var logs = new List<LogEntry>();
+
+            using (var sut = new CacheLoggerProvider(logs))
+            {
+                var logger = sut.CreateLogger(name);
+
+                logger.Should().BeOfType<CacheLogger>();
+
+                logger.Log(LogLevel.Error, eventId, state, exception, formatter);
+
+                logs.Should().HaveCount(1);
+                logs[0].EventId.Should().Be(eventId);
+                logs[0].Exception.Should().Be(exception);
+                logs[0].LogLevel.Should().Be(LogLevel.Error);
+                logs[0].State.Should().Be(state);
+                logs[0].Message.Should().Be(data);
+            }
+        }
+
+        [Fact]
+        public void ThrowsExceptionWhenCreatedWithNullLogsTest()
+        {
+            Action action = () => new CacheLoggerProvider(null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/Neovolve.UnitTest.UnitTests/Logging/CacheLoggerTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/CacheLoggerTests.cs
@@ -1,0 +1,92 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using ModelBuilder;
+using Neovolve.UnitTest.Logging;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Neovolve.UnitTest.UnitTests.Logging
+{
+    public class CacheLoggerTests
+    {
+        [Fact]
+        public void CacheLoggerTBeginScopeReturnsInstanceTest()
+        {
+            var logs = new List<LogEntry>();
+
+            var sut = new CacheLogger<CacheLoggerTests>(logs);
+
+            var actual = sut.BeginScope("Stuff");
+
+            actual.Should().NotBeNull();
+
+            Action action = () => actual.Dispose();
+
+            action.Should().NotThrow();
+        }
+
+        [Fact]
+        public void CacheLoggerThrowsExceptionWithNullLogsTest()
+        {
+            Action action = () => new CacheLogger(null);
+        }
+
+        [Fact]
+        public void CacheLoggerTThrowsExceptionWithNullLogsTest()
+        {
+            Action action = () => new CacheLogger<CacheLoggerTests>(null);
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.None)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warning)]
+        public void IsEnabledReturnsTrueTest(LogLevel logLevel)
+        {
+            var logs = new List<LogEntry>();
+
+            var sut = new CacheLogger<CacheLoggerTests>(logs);
+
+            var actual = sut.IsEnabled(logLevel);
+
+            actual.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.None)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warning)]
+        public void LogCachesLogMessageTest(LogLevel logLevel)
+        {
+            var eventId = Model.Create<EventId>();
+            var state = Guid.NewGuid().ToString();
+            var data = Guid.NewGuid().ToString();
+            var exception = new ArgumentNullException(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            Func<string, Exception, string> formatter = (string message, Exception error) =>
+            {
+                return data;
+            };
+            var logs = new List<LogEntry>();
+
+            var sut = new CacheLogger<CacheLoggerTests>(logs);
+
+            sut.Log(logLevel, eventId, state, exception, formatter);
+
+            logs.Should().HaveCount(1);
+            logs[0].EventId.Should().Be(eventId);
+            logs[0].Exception.Should().Be(exception);
+            logs[0].LogLevel.Should().Be(logLevel);
+            logs[0].State.Should().Be(state);
+            logs[0].Message.Should().Be(data);
+        }
+    }
+}

--- a/Neovolve.UnitTest.UnitTests/Logging/LogFactoryTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/LogFactoryTests.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using FluentAssertions;
     using Microsoft.Extensions.Logging;
     using Xunit;
@@ -38,7 +39,7 @@
             var logLevel = LogLevel.Information;
             var eventId = new EventId(Environment.TickCount);
             var state = new
-                {Name = Guid.NewGuid().ToString()};
+            { Name = Guid.NewGuid().ToString() };
             var exception = GetThrownException();
 
             var actual = _output.BuildLoggerFor<LogFactoryTests>();
@@ -58,6 +59,48 @@
             latest.State.Should().Be(state);
             latest.Exception.Should().Be(exception);
             latest.Message.Should().NotBeNullOrWhiteSpace();
+
+            var entries = actual.Entries;
+
+            entries.Count.Should().Be(actual.Count);
+
+            var entry = entries.First();
+
+            latest.Should().BeEquivalentTo(entry);
+        }
+
+        [Fact]
+        public void BuildLoggerForTypeCanBeginScopeTests()
+        {
+            var state = new
+            { Name = Guid.NewGuid().ToString() };
+
+            var actual = _output.BuildLoggerFor<LogFactoryTests>();
+
+            using (var scope = actual.BeginScope(state))
+            {
+                scope.Dispose();
+            }
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.None)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warning)]
+        public void BuildLoggerForTypeReturnsLoggerWithIsEnabledReturnsTrueTest(LogLevel logLevel)
+        {
+            var state = new
+            { Name = Guid.NewGuid().ToString() };
+
+            var logger = _output.BuildLoggerFor<LogFactoryTests>();
+
+            var actual = logger.IsEnabled(logLevel);
+
+            actual.Should().BeTrue();
         }
 
         [Theory]
@@ -66,7 +109,7 @@
         {
             var eventId = new EventId(Environment.TickCount);
             var state = new
-                {Name = Guid.NewGuid().ToString()};
+            { Name = Guid.NewGuid().ToString() };
             var exception = GetThrownException();
 
             var actual = _output.BuildLoggerFor<LogFactoryTests>();
@@ -80,7 +123,7 @@
         {
             var eventId = new EventId(Environment.TickCount);
             var state = new
-                {Name = Guid.NewGuid().ToString()};
+            { Name = Guid.NewGuid().ToString() };
             var exception = GetThrownException();
 
             var actual = _output.BuildLogger();

--- a/Neovolve.UnitTest.UnitTests/Logging/OutputLoggerProviderTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/OutputLoggerProviderTests.cs
@@ -1,0 +1,47 @@
+﻿using FluentAssertions;
+using Neovolve.UnitTest.Logging;
+using NSubstitute;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neovolve.UnitTest.UnitTests.Logging
+{
+    public class OutputLoggerProviderTests
+    {
+        [Fact]
+        public void CanDisposeMultipleTimesTest()
+        {
+            var output = Substitute.For<ITestOutputHelper>();
+
+            using (var sut = new OutputLoggerProvider(output))
+            {
+                sut.Dispose();
+                sut.Dispose();
+            }
+        }
+
+        [Fact]
+        public void CreateLoggerReturnsOutputLoggerTest()
+        {
+            var categoryName = Guid.NewGuid().ToString();
+
+            var output = Substitute.For<ITestOutputHelper>();
+
+            using (var sut = new OutputLoggerProvider(output))
+            {
+                var actual = sut.CreateLogger(categoryName);
+
+                actual.Should().BeOfType<OutputLogger>();
+            }
+        }
+
+        [Fact]
+        public void ThrowsExceptionWithNullOutputTest()
+        {
+            Action action = () => new OutputLoggerProvider(null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+    }
+}

--- a/Neovolve.UnitTest.UnitTests/Logging/OutputLoggerTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/OutputLoggerTests.cs
@@ -1,0 +1,95 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using ModelBuilder;
+using Neovolve.UnitTest.Logging;
+using NSubstitute;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neovolve.UnitTest.UnitTests.Logging
+{
+    public class OutputLoggerTests
+    {
+        [Fact]
+        public void BeginScopeReturnsInstanceTest()
+        {
+            var name = Guid.NewGuid().ToString();
+            var state = Guid.NewGuid().ToString();
+
+            var output = Substitute.For<ITestOutputHelper>();
+
+            var sut = new OutputLogger(name, output);
+
+            var actual = sut.BeginScope(state);
+
+            actual.Should().NotBeNull();
+
+            Action action = () => actual.Dispose();
+
+            action.Should().NotThrow();
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.None)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warning)]
+        public void IsEnabledReturnsTrueTest(LogLevel logLevel)
+        {
+            var state = Guid.NewGuid().ToString();
+            var name = Guid.NewGuid().ToString();
+
+            var output = Substitute.For<ITestOutputHelper>();
+
+            var sut = new OutputLogger(name, output);
+
+            var actual = sut.IsEnabled(logLevel);
+
+            actual.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(LogLevel.Critical)]
+        [InlineData(LogLevel.Debug)]
+        [InlineData(LogLevel.Error)]
+        [InlineData(LogLevel.Information)]
+        [InlineData(LogLevel.None)]
+        [InlineData(LogLevel.Trace)]
+        [InlineData(LogLevel.Warning)]
+        public void LogTest(LogLevel logLevel)
+        {
+            var eventId = Model.Create<EventId>();
+            var state = Guid.NewGuid().ToString();
+            var data = Guid.NewGuid().ToString();
+            var exception = new ArgumentNullException(Guid.NewGuid().ToString(), Guid.NewGuid().ToString());
+            Func<string, Exception, string> formatter = (string message, Exception error) =>
+            {
+                return data;
+            };
+            var name = Guid.NewGuid().ToString();
+
+            var output = Substitute.For<ITestOutputHelper>();
+
+            var sut = new OutputLogger(name, output);
+
+            sut.Log(logLevel, eventId, state, exception, formatter);
+
+            output.Received().WriteLine("{1} [{2}]: {3}", new object[]{
+                    name,
+                    logLevel,
+                    eventId.Id,
+                    data
+                });
+            output.Received().WriteLine("{1} [{2}]: {3}", new object[]{
+                    name,
+                    logLevel,
+                    eventId.Id,
+                    exception
+                });
+        }
+    }
+}

--- a/Neovolve.UnitTest.UnitTests/Logging/TestOutputHelperExtensionsTests.cs
+++ b/Neovolve.UnitTest.UnitTests/Logging/TestOutputHelperExtensionsTests.cs
@@ -1,0 +1,66 @@
+﻿using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using System;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Neovolve.UnitTest.UnitTests.Logging
+{
+    public class TestOutputHelperExtensionsTests
+    {
+        private readonly ITestOutputHelper _output;
+
+        public TestOutputHelperExtensionsTests(ITestOutputHelper output)
+        {
+            _output = output;
+        }
+
+        [Fact]
+        public void BuildLoggerForTReturnsILoggerTTest()
+        {
+            ILogger<TestOutputHelperExtensionsTests> logger = _output.BuildLoggerFor<TestOutputHelperExtensionsTests>();
+
+            logger.Should().BeAssignableTo<ILogger<TestOutputHelperExtensionsTests>>();
+        }
+
+        [Fact]
+        public void BuildLoggerForTReturnsUsableLoggerTest()
+        {
+            var logger = _output.BuildLoggerFor<TestOutputHelperExtensionsTests>();
+
+            logger.LogInformation("Hey, does this work? Check the test trace log.");
+        }
+
+        [Fact]
+        public void BuildLoggerForTThrowsExceptionWithNullOutputTTest()
+        {
+            Action action = () => TestOutputHelperExtensions.BuildLoggerFor<TestOutputHelperExtensionsTests>(null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void BuildLoggerThrowsExceptionWithNullOutputTTest()
+        {
+            Action action = () => TestOutputHelperExtensions.BuildLogger(null);
+
+            action.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void BuildReturnsILoggerTest()
+        {
+            var logger = _output.BuildLogger();
+
+            logger.Should().BeAssignableTo<ILogger>();
+        }
+
+        [Fact]
+        public void BuildReturnsUsableLoggerTest()
+        {
+            var logger = _output.BuildLogger();
+
+            logger.LogInformation("Hey, does this work? Check the test trace log.");
+        }
+    }
+}

--- a/Neovolve.UnitTest.UnitTests/Neovolve.UnitTest.UnitTests.csproj
+++ b/Neovolve.UnitTest.UnitTests/Neovolve.UnitTest.UnitTests.csproj
@@ -5,10 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="FluentAssertions" Version="5.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
+    <PackageReference Include="ModelBuilder" Version="4.1.1" />
+    <PackageReference Include="NSubstitute" Version="3.1.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.2.0" />
     <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Neovolve.UnitTest/Logging/CacheLogger.cs
+++ b/Neovolve.UnitTest/Logging/CacheLogger.cs
@@ -5,14 +5,13 @@
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    ///     The <see cref="CacheLogger" />
-    ///     class is used to provide logging implementation for caching log entries.
+    /// The <see cref="CacheLogger"/> class is used to provide logging implementation for caching log entries.
     /// </summary>
     /// <typeparam name="T">The type of class using the cache.</typeparam>
     public class CacheLogger<T> : CacheLogger, ILogger<T>
     {
         /// <summary>
-        ///     Creates a new instance of the <see cref="CacheLogger" /> class.
+        /// Creates a new instance of the <see cref="CacheLogger"/> class.
         /// </summary>
         /// <param name="logEntries">The log entries.</param>
         public CacheLogger(IList<LogEntry> logEntries)
@@ -22,35 +21,34 @@
     }
 
     /// <summary>
-    ///     The <see cref="CacheLogger" />
-    ///     class is used to provide logging implementation for caching log entries.
+    /// The <see cref="CacheLogger"/> class is used to provide logging implementation for caching log entries.
     /// </summary>
     public class CacheLogger : ILogger
     {
         private readonly IList<LogEntry> _logEntries;
 
         /// <summary>
-        ///     Creates a new instance of the <see cref="CacheLogger" /> class.
+        /// Creates a new instance of the <see cref="CacheLogger"/> class.
         /// </summary>
         /// <param name="logEntries">The log entries.</param>
         public CacheLogger(IList<LogEntry> logEntries)
         {
-            _logEntries = logEntries;
+            _logEntries = logEntries ?? throw new ArgumentNullException(nameof(logEntries));
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public IDisposable BeginScope<TState>(TState state)
         {
             return NoopDisposable.Instance;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public bool IsEnabled(LogLevel logLevel)
         {
             return true;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void Log<TState>(
             LogLevel logLevel,
             EventId eventId,

--- a/Neovolve.UnitTest/Logging/CacheLoggerProvider.cs
+++ b/Neovolve.UnitTest/Logging/CacheLoggerProvider.cs
@@ -1,32 +1,32 @@
 ﻿namespace Neovolve.UnitTest.Logging
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.Extensions.Logging;
 
     /// <summary>
-    ///     The <see cref="CacheLoggerProvider" />
-    ///     class is used to provide Xunit logging to <see cref="ILoggerFactory" />.
+    /// The <see cref="CacheLoggerProvider"/> class is used to provide Xunit logging to <see cref="ILoggerFactory"/>.
     /// </summary>
     public class CacheLoggerProvider : ILoggerProvider
     {
         private readonly IList<LogEntry> _logEntries;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="CacheLoggerProvider" /> class.
+        /// Initializes a new instance of the <see cref="CacheLoggerProvider"/> class.
         /// </summary>
         /// <param name="logEntries">The log entries.</param>
         public CacheLoggerProvider(IList<LogEntry> logEntries)
         {
-            _logEntries = logEntries;
+            _logEntries = logEntries ?? throw new ArgumentNullException(nameof(logEntries));
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName)
         {
             return new CacheLogger(_logEntries);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void Dispose()
         {
             // no-op

--- a/Neovolve.UnitTest/Logging/OutputLoggerProvider.cs
+++ b/Neovolve.UnitTest/Logging/OutputLoggerProvider.cs
@@ -1,32 +1,32 @@
 ﻿namespace Neovolve.UnitTest.Logging
 {
     using Microsoft.Extensions.Logging;
+    using System;
     using Xunit.Abstractions;
 
     /// <summary>
-    ///     The <see cref="OutputLoggerProvider" />
-    ///     class is used to provide Xunit logging to <see cref="ILoggerFactory" />.
+    /// The <see cref="OutputLoggerProvider"/> class is used to provide Xunit logging to <see cref="ILoggerFactory"/>.
     /// </summary>
     public class OutputLoggerProvider : ILoggerProvider
     {
         private readonly ITestOutputHelper _output;
 
         /// <summary>
-        ///     Initializes a new instance of the <see cref="OutputLoggerProvider" /> class.
+        /// Initializes a new instance of the <see cref="OutputLoggerProvider"/> class.
         /// </summary>
         /// <param name="output">The test output helper.</param>
         public OutputLoggerProvider(ITestOutputHelper output)
         {
-            _output = output;
+            _output = output ?? throw new ArgumentNullException(nameof(output));
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public ILogger CreateLogger(string categoryName)
         {
             return new OutputLogger(categoryName, _output);
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public void Dispose()
         {
             // no-op

--- a/Neovolve.UnitTest/Logging/TestOutputHelperExtensions.cs
+++ b/Neovolve.UnitTest/Logging/TestOutputHelperExtensions.cs
@@ -5,21 +5,19 @@
     using Neovolve.UnitTest.Logging;
 
     /// <summary>
-    ///     The <see cref="TestOutputHelperExtensions" />
-    ///     class provides extension methods for the <see cref="ITestOutputHelper" />.
+    /// The <see cref="TestOutputHelperExtensions"/> class provides extension methods for the <see cref="ITestOutputHelper"/>.
     /// </summary>
     public static class TestOutputHelperExtensions
     {
         /// <summary>
-        ///     Builds a logger from the specified test output helper.
+        /// Builds a logger from the specified test output helper.
         /// </summary>
         /// <param name="output">The test output helper.</param>
         /// <param name="memberName">
-        ///     The member to create the logger for. This is automatically populated using
-        ///     <see cref="CallerMemberNameAttribute" />.
+        /// The member to create the logger for. This is automatically populated using <see cref="CallerMemberNameAttribute"/>.
         /// </param>
         /// <returns>The logger.</returns>
-        /// <exception cref="ArgumentNullException">The <paramref name="output" /> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentNullException">The <paramref name="output"/> is <c>null</c>.</exception>
         public static ICacheLogger BuildLogger(this ITestOutputHelper output, [CallerMemberName] string memberName = "")
         {
             if (output == null)
@@ -31,13 +29,13 @@
         }
 
         /// <summary>
-        ///     Builds a logger from the specified test output helper for the specified type.
+        /// Builds a logger from the specified test output helper for the specified type.
         /// </summary>
         /// <typeparam name="T">The type to create the logger for.</typeparam>
         /// <param name="output">The test output helper.</param>
         /// <returns>The logger.</returns>
-        /// <exception cref="ArgumentNullException">The <paramref name="output" /> is <c>null</c>.</exception>
-        public static ICacheLogger BuildLoggerFor<T>(this ITestOutputHelper output)
+        /// <exception cref="ArgumentNullException">The <paramref name="output"/> is <c>null</c>.</exception>
+        public static ICacheLogger<T> BuildLoggerFor<T>(this ITestOutputHelper output)
         {
             if (output == null)
             {


### PR DESCRIPTION
Fixed bug in TestOutputHelperExtensions where a non-generic logger was returned by BuildLoggerFor<T>.